### PR TITLE
Fix broken parsing of responses with only a status code

### DIFF
--- a/src/check-status.js
+++ b/src/check-status.js
@@ -16,7 +16,10 @@ async function parseJSONError(response) {
 	} catch {
 		// there was an error trying to parse the JSON body (maybe it's not JSON?)
 		// just ignore it and return an error with the original response without a parsed body
-		let error = new Error(response.statusText);
+		let error = new Error(
+			response.statusText ||
+				`Request failed with status code ${response.status}`
+		);
 		error.response = response;
 		throw error;
 	}

--- a/src/connect.js
+++ b/src/connect.js
@@ -197,7 +197,7 @@ const connect = fn => DecoratedComponent =>
 						data: prevState[key].data,
 						isFetching: false,
 						isFetched: prevState[key].isFetched,
-						error: ex.message
+						error: ex
 					}
 				}));
 			}

--- a/test/connect.js
+++ b/test/connect.js
@@ -117,7 +117,13 @@ describe("Connecting a component to fetch", function() {
 
 				expect(bananas.isFetching).to.be.false;
 				expect(bananas.isFetched).to.be.false;
-				expect(bananas.error).to.equal("Not today, buddy");
+
+				expect(bananas.error).to.be.ok;
+				expect(bananas.error).to.be.an("error");
+
+				expect(bananas.error.message).to.equal("Not today, buddy");
+				expect(bananas.error.response).to.be.ok;
+				expect(bananas.error.response.status).to.equal(500);
 
 				expect(bananas.data).to.not.be.ok;
 			});
@@ -280,7 +286,13 @@ describe("Connecting a component to fetch", function() {
 
 				expect(bananas.isFetching).to.be.false;
 				expect(bananas.isFetched).to.be.false;
-				expect(bananas.error).to.equal("Not today, buddy");
+
+				expect(bananas.error).to.be.ok;
+				expect(bananas.error).to.be.an("error");
+
+				expect(bananas.error.message).to.equal("Not today, buddy");
+				expect(bananas.error.response).to.be.ok;
+				expect(bananas.error.response.status).to.equal(500);
 
 				expect(bananas.data).to.not.be.ok;
 			});
@@ -440,7 +452,7 @@ describe("Connecting a component to fetch", function() {
 								new Promise(resolve =>
 									resolve(
 										new Promise(() => {
-											throw { message: "wow you messed up" };
+											throw new Error("wow you messed up");
 										})
 									)
 								)
@@ -469,7 +481,12 @@ describe("Connecting a component to fetch", function() {
 
 			expect(bananas.isFetching).to.be.false;
 			expect(bananas.isFetched).to.be.false;
-			expect(bananas.error).to.equal("wow you messed up");
+
+			expect(bananas.error).to.be.ok;
+			expect(bananas.error).to.be.an("error");
+
+			expect(bananas.error.message).to.equal("wow you messed up");
+			expect(bananas.error.response).to.not.be.ok;
 
 			expect(bananas.data).to.not.be.ok;
 		});

--- a/test/parsing-response.js
+++ b/test/parsing-response.js
@@ -57,6 +57,21 @@ describe("Parsing Responses", function() {
 			});
 		}
 
+		describe("with no error message or status text", function() {
+			beforeEach(function() {
+				this.resolve({ status: 404 });
+			});
+
+			shouldRejectWithError(404);
+
+			it("should use a generic error message", function(done) {
+				this.result.catch(err => {
+					expect(err.message).to.equal("Request failed with status code 404");
+					done();
+				});
+			});
+		});
+
 		describe("with an error message", function() {
 			beforeEach(function() {
 				this.resolve({


### PR DESCRIPTION
Also return the full error message when using connect instead of just the message.